### PR TITLE
Support TestRule along with MethodRule

### DIFF
--- a/arquillian-rule/src/test/java/org/jboss/aerogear/arquillian/junit/MethodRuleExecutionTest.java
+++ b/arquillian-rule/src/test/java/org/jboss/aerogear/arquillian/junit/MethodRuleExecutionTest.java
@@ -1,7 +1,5 @@
 package org.jboss.aerogear.arquillian.junit;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
 import org.jboss.arquillian.junit.InSequence;
 import org.junit.Assert;
 import org.junit.Test;
@@ -12,18 +10,17 @@ import org.junit.runner.RunWith;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.Statement;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 
 @RunWith(ArquillianRules.class)
-public class RuleExecutionTest {
+public class MethodRuleExecutionTest {
 
     private AtomicInteger methodRuleCounter = new AtomicInteger(0);
     private static AtomicInteger staticMethodRuleCounter = new AtomicInteger(0);
     
-    private AtomicInteger testRuleCounter = new AtomicInteger(0);
-    private static AtomicInteger staticTestRuleCounter = new AtomicInteger(0);
-
     @ArquillianRule
     public MethodRule simpleMethodRule = new MethodRule() {
 
@@ -42,24 +39,6 @@ public class RuleExecutionTest {
         }
     };
 
-    @ArquillianRule
-    public TestRule simpleTestRule = new TestRule() {
-
-        @Override
-        public Statement apply(final Statement base, Description description) {
-
-            return new Statement() {
-                public void evaluate() throws Throwable {
-                    testRuleCounter.incrementAndGet();
-                    staticTestRuleCounter.incrementAndGet();
-                    base.evaluate();
-                    testRuleCounter.incrementAndGet();
-                    staticTestRuleCounter.incrementAndGet();
-                };
-            };
-        }
-    };
-
     @Test
     @InSequence(1)
     public void applyRuleOnce() throws Exception {
@@ -67,10 +46,6 @@ public class RuleExecutionTest {
         Assert.assertThat(methodRuleCounter.get(), is(1));
         Assert.assertThat(staticMethodRuleCounter, is(notNullValue()));
         Assert.assertThat(staticMethodRuleCounter.get(), is(1));
-        Assert.assertThat(testRuleCounter, is(notNullValue()));
-        Assert.assertThat(testRuleCounter.get(), is(1));
-        Assert.assertThat(staticTestRuleCounter, is(notNullValue()));
-        Assert.assertThat(staticTestRuleCounter.get(), is(1));
     }
 
     @Test
@@ -80,10 +55,6 @@ public class RuleExecutionTest {
         Assert.assertThat(methodRuleCounter.get(), is(1));
         Assert.assertThat(staticMethodRuleCounter, is(notNullValue()));
         Assert.assertThat(staticMethodRuleCounter.get(), is(3));
-        Assert.assertThat(testRuleCounter, is(notNullValue()));
-        Assert.assertThat(testRuleCounter.get(), is(1));
-        Assert.assertThat(staticTestRuleCounter, is(notNullValue()));
-        Assert.assertThat(staticTestRuleCounter.get(), is(3));
     }
 
 }

--- a/arquillian-rule/src/test/java/org/jboss/aerogear/arquillian/junit/TestRuleExecutionTest.java
+++ b/arquillian-rule/src/test/java/org/jboss/aerogear/arquillian/junit/TestRuleExecutionTest.java
@@ -1,7 +1,5 @@
 package org.jboss.aerogear.arquillian.junit;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
 import org.jboss.arquillian.junit.InSequence;
 import org.junit.Assert;
 import org.junit.Test;
@@ -12,35 +10,17 @@ import org.junit.runner.RunWith;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.Statement;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 
 @RunWith(ArquillianRules.class)
-public class RuleExecutionTest {
+public class TestRuleExecutionTest {
 
-    private AtomicInteger methodRuleCounter = new AtomicInteger(0);
-    private static AtomicInteger staticMethodRuleCounter = new AtomicInteger(0);
-    
     private AtomicInteger testRuleCounter = new AtomicInteger(0);
     private static AtomicInteger staticTestRuleCounter = new AtomicInteger(0);
 
-    @ArquillianRule
-    public MethodRule simpleMethodRule = new MethodRule() {
-
-        @Override
-        public Statement apply(final Statement base, FrameworkMethod method, Object target) {
-
-            return new Statement() {
-                public void evaluate() throws Throwable {
-                    methodRuleCounter.incrementAndGet();
-                    staticMethodRuleCounter.incrementAndGet();
-                    base.evaluate();
-                    methodRuleCounter.incrementAndGet();
-                    staticMethodRuleCounter.incrementAndGet();
-                };
-            };
-        }
-    };
 
     @ArquillianRule
     public TestRule simpleTestRule = new TestRule() {
@@ -63,10 +43,6 @@ public class RuleExecutionTest {
     @Test
     @InSequence(1)
     public void applyRuleOnce() throws Exception {
-        Assert.assertThat(methodRuleCounter, is(notNullValue()));
-        Assert.assertThat(methodRuleCounter.get(), is(1));
-        Assert.assertThat(staticMethodRuleCounter, is(notNullValue()));
-        Assert.assertThat(staticMethodRuleCounter.get(), is(1));
         Assert.assertThat(testRuleCounter, is(notNullValue()));
         Assert.assertThat(testRuleCounter.get(), is(1));
         Assert.assertThat(staticTestRuleCounter, is(notNullValue()));
@@ -76,10 +52,6 @@ public class RuleExecutionTest {
     @Test
     @InSequence(2)
     public void applyRuleSecond() throws Exception {
-        Assert.assertThat(methodRuleCounter, is(notNullValue()));
-        Assert.assertThat(methodRuleCounter.get(), is(1));
-        Assert.assertThat(staticMethodRuleCounter, is(notNullValue()));
-        Assert.assertThat(staticMethodRuleCounter.get(), is(3));
         Assert.assertThat(testRuleCounter, is(notNullValue()));
         Assert.assertThat(testRuleCounter.get(), is(1));
         Assert.assertThat(staticTestRuleCounter, is(notNullValue()));


### PR DESCRIPTION
MethodRule has been replaced by TestRule in JUnit 4.9. See JavaDoc for MethodRule.

ArquillianRules now supports usage of both, even mixed.